### PR TITLE
Remove old stages from `dvc.lock`

### DIFF
--- a/dvc.lock
+++ b/dvc.lock
@@ -1,56 +1,47 @@
+---
 schema: '2.0'
 stages:
-  1-stage:
-    cmd: Rscript stages/01-stage.R
-    deps:
-    - path: stages/01-stage.R
-      md5: c468dc14527e00c339f146e1dba2bd3b
-      size: 118
-    outs:
-    - path: data/mtcars.parquet
-      md5: 77cf29accf9535522fad7db1486eff9a
-      size: 6243
-  download:
-    cmd: stages/01_download.sh
-    deps:
-    - path: stages/01_download.sh
-      md5: 9ad7abc4441bb03db746763323943f66
-      size: 558
-    outs:
-    - path: download
-      md5: 4f1c0c762afa84306d347f4b366b11d2.dir
-      size: 93725827
-      nfiles: 1
-  unzip:
-    cmd: stages/02_unzip.sh
-    deps:
-    - path: download
-      md5: 4f1c0c762afa84306d347f4b366b11d2.dir
-      size: 93725827
-      nfiles: 1
-    - path: stages/02_unzip.sh
-      md5: d0e1b99ce0d7915c3becc3fa210348d2
-      size: 466
-    outs:
-    - path: raw
-      md5: 75ab6120bac0a1065986912e5e5eb79b.dir
-      size: 572654300
-      nfiles: 11
   build:
     cmd: stages/03_build.sh
     deps:
-    - path: raw
-      md5: 75ab6120bac0a1065986912e5e5eb79b.dir
-      size: 572654300
+    - md5: 75ab6120bac0a1065986912e5e5eb79b.dir
       nfiles: 11
-    - path: stages/03_build.sh
-      md5: ad705d3aff32f182707d7aa88a87fd18
+      path: raw
+      size: 572654300
+    - md5: ad705d3aff32f182707d7aa88a87fd18
+      path: stages/03_build.sh
       size: 410
-    - path: stages/csv2parquet.py
-      md5: 9fe6f058abb56acd3f330ec3d1e34e03
+    - md5: 9fe6f058abb56acd3f330ec3d1e34e03
+      path: stages/csv2parquet.py
       size: 660
     outs:
-    - path: brick
-      md5: 92fec7f055de167dfabdea546b4fa407.dir
-      size: 155500050
+    - md5: 92fec7f055de167dfabdea546b4fa407.dir
       nfiles: 10
+      path: brick
+      size: 155500050
+  download:
+    cmd: stages/01_download.sh
+    deps:
+    - md5: 9ad7abc4441bb03db746763323943f66
+      path: stages/01_download.sh
+      size: 558
+    outs:
+    - md5: 4f1c0c762afa84306d347f4b366b11d2.dir
+      nfiles: 1
+      path: download
+      size: 93725827
+  unzip:
+    cmd: stages/02_unzip.sh
+    deps:
+    - md5: 4f1c0c762afa84306d347f4b366b11d2.dir
+      nfiles: 1
+      path: download
+      size: 93725827
+    - md5: d0e1b99ce0d7915c3becc3fa210348d2
+      path: stages/02_unzip.sh
+      size: 466
+    outs:
+    - md5: 75ab6120bac0a1065986912e5e5eb79b.dir
+      nfiles: 11
+      path: raw
+      size: 572654300


### PR DESCRIPTION
Many bricks have old stages from the brick-template.
